### PR TITLE
Remove support for PHP 5.4, add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-- 5.4
 - 5.5
 - 5.6
 - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ php:
 - 5.6
 - 7.0
 - hhvm
-install: composer install
+install: composer dump-autoload
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+php:
+- 5.4
+- 5.5
+- 5.6
+- 7.0
+- hhvm
+script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ php:
 - 5.6
 - 7.0
 - hhvm
+install: composer install
 script: phpunit

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Create configuartion arrays for [Advanced Custom Fields Pro](https://www.advance
 
 Quickly create, register, and reuse ACF configurations, and keep them in your source code repository. To read more about registering ACF fields via php consult https://www.advancedcustomfields.com/resources/register-fields-via-php/
 
+![Build Status](https://api.travis-ci.org/StoutLogic/acf-builder.svg?branch=master)
+
 ### Simple Example
 ```php
 $banner = new StoutLogic\AcfBuilder\FieldsBuilder('banner');
@@ -12,7 +14,7 @@ $banner
     ->addImage('background_image')
     ->setLocation('post_type', '==', 'page')
         ->or('post_type', '==', 'post');
-       
+
 add_action('acf/init', function() {
    acf_add_local_field_group($banner->build());
 });
@@ -77,14 +79,14 @@ $background
     ->addTrueFalse('fixed')
         ->instructions("Check to add a parallax effect where the background image doesn't move when scrolling")
     ->addColorPicker('background_color');
-           
+
 $banner = new FieldsBuilder('banner');
 $banner
     ->addTab('Content')
     ->addText('title')
     ->addWysiwyg('content')
     ->addFields($background);
-           
+
 $section = new FieldsBuilder('section');
 $section
     ->addTab('Content')
@@ -117,5 +119,8 @@ npm install
 gulp
 ```
 
+## Requirements
+At this time only PHP 5.5 and later are supported. This is due to the use of [::class](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class)
+
 ## Documentation
-See the [wiki](https://github.com/StoutLogic/acf-builder/wiki) for more thorough documenation.
+See the [wiki](https://github.com/StoutLogic/acf-builder/wiki) for more thorough documentation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ACF Builder
-Create configuartion arrays for [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/) using the builder pattern and a fluent API.
+Create configuration arrays for [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/) using the builder pattern and a fluent API.
 
 Quickly create, register, and reuse ACF configurations, and keep them in your source code repository. To read more about registering ACF fields via php consult https://www.advancedcustomfields.com/resources/register-fields-via-php/
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "stoutlogic/acf-builder",
     "description": "An Advanced Custom Field Configuration Builder",
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.0.*"


### PR DESCRIPTION
Since our code base and tests use `::class` we need to drop PHP 5.4