### PR TITLE
Fix a bug in addFields causing ACF warnings

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -107,7 +107,7 @@ class FieldsBuilder extends Builder
      */
     public function addFields($fields)
     {
-        if (is_subclass_of($fields, FieldsBuilder::class)) {
+        if (is_a($fields, FieldsBuilder::class)) {
             $fields = clone $fields;
             foreach ($fields->getFields() as $field) {
                 $this->pushField($field);

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -811,20 +811,10 @@ class FieldsBuilderTest extends \PHPUnit_Framework_TestCase
 
     function testAddAnotherBuildersFields()
     {
-        $banner = $this->getMockBuilder('StoutLogic\AcfBuilder\FieldsBuilder')
-                        ->setConstructorArgs(['parent'])
-                        ->getMock();
-
-        $banner->expects($this->any())->method('getFields')->willReturn([
-                [
-                    'name' => 'title',
-                    'type' => 'text',
-                ],
-                [
-                    'name' => 'content',
-                    'type' => 'wysiwyg',
-                ]
-            ]);
+        $banner = new FieldsBuilder('banner');
+        $banner
+            ->addText('title')
+            ->addWysiwyg('content');
 
         $builder = new FieldsBuilder('content');
         $builder->addTextarea('summary')
@@ -840,6 +830,7 @@ class FieldsBuilderTest extends \PHPUnit_Framework_TestCase
                 ],
                 [
                     'name' => 'title',
+                    'label' => 'Title',
                     'type' => 'text',
                 ],
                 [
@@ -849,6 +840,7 @@ class FieldsBuilderTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         $this->assertArraySubset($expectedConfig, $builder->build());
+        print_r($builder->build());
     }
 
     public function testLocation()


### PR DESCRIPTION
Use a real FieldsBuilder to test addFields with, instead of mocking one.

Issue #8