### PR TITLE
Added methods to work with wrapper

### DIFF
--- a/src/FieldBuilder.php
+++ b/src/FieldBuilder.php
@@ -248,19 +248,46 @@ class FieldBuilder extends ParentDelegationBuilder implements NamedBuilder
     public function setAttr($name, $value = null)
     {
         $wrapper = $this->getWrapper();
-        // define smart class/id value specified in a $name parameter.
-        if (is_null($value) && 0 === strpos($name, '.')) {
-            $value = str_replace('.', ' ', trim($name, '.'));
-            $name = 'class';
-        }
-        if (is_null($value) && 0 === strpos($name, '#')) {
-            $value = trim($name, '#');
-            $name = 'id';
-        }
+        
         // set attribute.
         $wrapper[$name] = $value;
 
         return $this->setWrapper($wrapper);
+    }
+
+    /**
+     * Set Class and/or ID attribute of a Wrapper container
+     * use CSS-like selector string to specify css or id
+     * example: #my-id.foo-class.bar-class
+     *
+     * @param string $css_selector
+     *
+     * @return FieldBuilder
+     */
+    public function setSelector($css_selector)
+    {
+        // if # is the first sign - we start with ID.
+        if (0 === strpos($css_selector, '#')) {
+            $css_selector .= '.'; // prevent empty second part.
+            list($id, $class) = explode('.', $css_selector, 2);
+        } else {
+            $css_selector .= '#'; // prevent empty second part.
+            list($class, $id) = explode('#', $css_selector, 2);
+        }
+
+        $id = trim($id, '#');
+        $class = trim($class, '.');
+
+        if (! empty($id)) {
+            $this->setAttr('id', $id);
+        }
+
+        if (! empty($class)) {
+            $class = str_replace('.', ' ', $class);
+            $this->setAttr('class', $class);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/FieldBuilder.php
+++ b/src/FieldBuilder.php
@@ -250,12 +250,12 @@ class FieldBuilder extends ParentDelegationBuilder implements NamedBuilder
         $wrapper = $this->getWrapper();
         // define smart class/id value specified in a $name parameter.
         if (is_null($value) && 0 === strpos($name, '.')) {
-            $name = 'class';
             $value = str_replace('.', ' ', trim($name, '.'));
+            $name = 'class';
         }
         if (is_null($value) && 0 === strpos($name, '#')) {
-            $name = 'id';
             $value = trim($name, '#');
+            $name = 'id';
         }
         // set attribute.
         $wrapper[$name] = $value;

--- a/src/FieldBuilder.php
+++ b/src/FieldBuilder.php
@@ -197,6 +197,73 @@ class FieldBuilder extends ParentDelegationBuilder implements NamedBuilder
     }
 
     /**
+     * Set Wrapper container tag attributes
+     *
+     * @param array $config
+     *
+     * @return FieldBuilder
+     */
+    public function setWrapper($config)
+    {
+        return $this->setConfig('wrapper', $config);
+    }
+
+    /**
+     * Get Wrapper container tag attributes
+     *
+     * @return array|mixed
+     */
+    public function getWrapper()
+    {
+        if (isset($this->config['wrapper'])) {
+            return $this->config['wrapper'];
+        }
+
+        return [];
+    }
+
+    /**
+     * Set width of a Wrapper container
+     *
+     * @param string $width Width of a container in % or px.
+     *
+     * @return FieldBuilder
+     */
+    public function setWidth($width)
+    {
+        $wrapper = $this->getWrapper();
+        $wrapper['width'] = $width;
+
+        return $this->setWrapper($wrapper);
+    }
+
+    /**
+     * Set specified Attr of a Wrapper container
+     *
+     * @param string $name Attribute name, ex. 'class'.
+     * @param string|null $value Attribute value, ex. 'my-class'.
+     *
+     * @return FieldBuilder
+     */
+    public function setAttr($name, $value = null)
+    {
+        $wrapper = $this->getWrapper();
+        // define smart class/id value specified in a $name parameter.
+        if (is_null($value) && 0 === strpos($name, '.')) {
+            $name = 'class';
+            $value = str_replace('.', ' ', trim($name, '.'));
+        }
+        if (is_null($value) && 0 === strpos($name, '#')) {
+            $name = 'id';
+            $value = trim($name, '#');
+        }
+        // set attribute.
+        $wrapper[$name] = $value;
+
+        return $this->setWrapper($wrapper);
+    }
+
+    /**
      * Build the field configuration array
      * @return array Field configuration array
      */

--- a/tests/FieldBuilderTest.php
+++ b/tests/FieldBuilderTest.php
@@ -146,6 +146,116 @@ class FieldBuilderTest extends \PHPUnit_Framework_TestCase
             ], $subject->build());
     }
 
+    public function testGetWrapper()
+    {
+        $wrapper = [
+            'class' => 'foo',
+            'id'    => 'bar',
+        ];
+        $subject = new FieldBuilder('my_field', 'text', ['wrapper' => $wrapper]);
+        $this->assertSame($subject, $subject->setConfig('prepend', '@'));
+        $this->assertArraySubset($wrapper, $subject->getWrapper());
+    }
+
+    public function testSetWrapper()
+    {
+        $subject = new FieldBuilder('my_field', 'text');
+        $this->assertSame($subject, $subject->setWrapper(['class' => 'foo', 'id' => 'bar']));
+        $this->assertArraySubset([
+            'key'     => 'field_my_field',
+            'name'    => 'my_field',
+            'label'   => 'My Field',
+            'type'    => 'text',
+            'wrapper' => [
+                'class' => 'foo',
+                'id'    => 'bar',
+            ],
+        ], $subject->build());
+    }
+
+    public function testSetWidth()
+    {
+        $subject = new FieldBuilder('my_field', 'text');
+        $this->assertSame($subject, $subject->setWidth('50%'));
+        $this->assertArraySubset([
+            'key'     => 'field_my_field',
+            'name'    => 'my_field',
+            'label'   => 'My Field',
+            'type'    => 'text',
+            'wrapper' => [
+                'width' => '50%',
+            ],
+        ], $subject->build());
+    }
+    
+    public function testSetAttr()
+    {
+        $subject = new FieldBuilder('my_field', 'text');
+        $this->assertSame($subject, $subject->setAttr('data-my_attr', 'My Attr'));
+        $this->assertArraySubset([
+            'key'     => 'field_my_field',
+            'name'    => 'my_field',
+            'label'   => 'My Field',
+            'type'    => 'text',
+            'wrapper' => [
+                'data-my_attr' => 'My Attr',
+            ],
+        ], $subject->build());
+    }
+
+    public function testSetSelector()
+    {
+        $subject = new FieldBuilder('my_field', 'text');
+        // returns FieldBuilder.
+        $this->assertSame($subject, $subject->setSelector('.my-class'));
+
+        // only id.
+        $subject->setSelector('#my-id');
+        $this->assertArraySubset([
+            'id' => 'my-id',
+        ], $subject->getWrapper());
+
+        // only class.
+        $subject->setSelector('.my-class');
+        $this->assertArraySubset([
+            'class' => 'my-class',
+        ], $subject->getWrapper());
+
+        // only class multiple.
+        $subject->setSelector('.class1.class2');
+        $this->assertArraySubset([
+            'class' => 'class1 class2',
+        ], $subject->getWrapper());
+
+        // id / class.
+        $subject->setSelector('#my-id.my-class');
+        $this->assertArraySubset([
+            'id'    => 'my-id',
+            'class' => 'my-class',
+        ], $subject->getWrapper());
+
+        // id / class multiple.
+        $subject->setSelector('#my-id.my-class.more-class');
+        $this->assertArraySubset([
+            'id'    => 'my-id',
+            'class' => 'my-class more-class',
+        ], $subject->getWrapper());
+
+        // class /id.
+        $subject->setSelector('.my-class#my-id');
+        $this->assertArraySubset([
+            'id'    => 'my-id',
+            'class' => 'my-class',
+        ], $subject->getWrapper());
+
+        // class multiple /id.
+        $subject->setSelector('.my-class.more-class#my-id');
+        $this->assertArraySubset([
+            'id'    => 'my-id',
+            'class' => 'my-class more-class',
+        ], $subject->getWrapper());
+    }
+
     public function testConditional()
     {
         $subject = new FieldBuilder('my_field', 'text', ['prepend' => '$']);


### PR DESCRIPTION
according to an issue: https://github.com/StoutLogic/acf-builder/issues/64

new methods to work with Wrapper config

Usage example:

```
	->addText( 'slider_title' )
	->setWidth( '50%' )
	->setSelector( '#my-id.my-class' )
	->addText( 'slider_subtitle' )
	->setWidth( '50%' )
	->setAttr( 'data-custom_attr', 'thisisattr' )
```