### PR TITLE
Added missing annotation for addRange function

### DIFF
--- a/src/FieldBuilder.php
+++ b/src/FieldBuilder.php
@@ -32,6 +32,7 @@ namespace StoutLogic\AcfBuilder;
  * @method FieldBuilder addGoogleMap(string $name, array $args = [])
  * @method FieldBuilder addLink(string $name, array $args = [])
  * @method FieldBuilder addTab(string $label, array $args = [])
+ * @method FieldBuilder addRange(string $label, array $args = [])
  * @method FieldBuilder addMessage(string $label, string $message, array $args = [])
  * @method GroupBuilder addGroup(string $name, array $args = [])
  * @method RepeaterBuilder addRepeater(string $name, array $args = [])

--- a/src/FieldBuilder.php
+++ b/src/FieldBuilder.php
@@ -32,12 +32,15 @@ namespace StoutLogic\AcfBuilder;
  * @method FieldBuilder addGoogleMap(string $name, array $args = [])
  * @method FieldBuilder addLink(string $name, array $args = [])
  * @method FieldBuilder addTab(string $label, array $args = [])
- * @method FieldBuilder addRange(string $label, array $args = [])
+ * @method FieldBuilder addRange(string $name, array $args = [])
  * @method FieldBuilder addMessage(string $label, string $message, array $args = [])
  * @method GroupBuilder addGroup(string $name, array $args = [])
+ * @method GroupBuilder endGroup()
  * @method RepeaterBuilder addRepeater(string $name, array $args = [])
+ * @method Builder endRepeater()
  * @method FlexibleContentBuilder addFlexibleContent(string $name, array $args = [])
  * @method FieldsBuilder addLayout(string|FieldsBuilder $layout, array $args = [])
+ * @method LocationBuilder setLocation(string $param, string $operator, string $value)*
  */
 class FieldBuilder extends ParentDelegationBuilder implements NamedBuilder
 {


### PR DESCRIPTION
addRange was added to FieldsBuilder as part of 1.5.0 in 2017, however
individual functions return instances of FieldBuilder, which doesn't
include the function.  IDE's display function undefined warnings as a
result.

addRange does however work as intended, so this just adds the annotation
so IDE's can provide functionality like autocompletion