### PR TITLE
Makes parent context dependency for GroupBuilder class injectible

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -567,7 +567,7 @@ class FieldsBuilder extends ParentDelegationBuilder implements NamedBuilder
      */
     public function addGroup($name, array $args = [])
     {
-        return $this->initializeField(new GroupBuilder($name, 'group', $args));
+        return $this->initializeField(new GroupBuilder($name, new self($name), 'group', $args));
     }
 
     /**
@@ -580,7 +580,7 @@ class FieldsBuilder extends ParentDelegationBuilder implements NamedBuilder
      */
     public function addRepeater($name, array $args = [])
     {
-        return $this->initializeField(new RepeaterBuilder($name, 'repeater', $args));
+        return $this->initializeField(new RepeaterBuilder($name, new self($name), 'repeater', $args));
     }
 
     /**

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -567,7 +567,7 @@ class FieldsBuilder extends ParentDelegationBuilder implements NamedBuilder
      */
     public function addGroup($name, array $args = [])
     {
-        return $this->initializeField(new GroupBuilder($name, new self($name), 'group', $args));
+        return $this->initializeField(new GroupBuilder($name, 'group', $args, new self($name)));
     }
 
     /**
@@ -580,7 +580,7 @@ class FieldsBuilder extends ParentDelegationBuilder implements NamedBuilder
      */
     public function addRepeater($name, array $args = [])
     {
-        return $this->initializeField(new RepeaterBuilder($name, new self($name), 'repeater', $args));
+        return $this->initializeField(new RepeaterBuilder($name, 'repeater', $args, new self($name)));
     }
 
     /**

--- a/src/GroupBuilder.php
+++ b/src/GroupBuilder.php
@@ -19,10 +19,10 @@ class GroupBuilder extends FieldBuilder
      * @param string $type Field name
      * @param array $config Field configuration
      */
-    public function __construct($name, FieldsBuilder $builder, $type = 'group', $config = [])
+    public function __construct($name, $type = 'group', $config = [], FieldsBuilder $builder = null)
     {
         parent::__construct($name, $type, $config);
-        $this->fieldsBuilder = $builder;
+        $this->fieldsBuilder = $builder ?: new FieldsBuilder($name);
         $this->fieldsBuilder->setParentContext($this);
     }
 

--- a/src/GroupBuilder.php
+++ b/src/GroupBuilder.php
@@ -19,10 +19,10 @@ class GroupBuilder extends FieldBuilder
      * @param string $type Field name
      * @param array $config Field configuration
      */
-    public function __construct($name, $type = 'group', $config = [])
+    public function __construct($name, FieldsBuilder $builder, $type = 'group', $config = [])
     {
         parent::__construct($name, $type, $config);
-        $this->fieldsBuilder = new FieldsBuilder($name);
+        $this->fieldsBuilder = $builder;
         $this->fieldsBuilder->setParentContext($this);
     }
 

--- a/src/RepeaterBuilder.php
+++ b/src/RepeaterBuilder.php
@@ -21,9 +21,9 @@ class RepeaterBuilder extends GroupBuilder
      * @param string $type Field name
      * @param array $config Field configuration
      */
-    public function __construct($name, FieldsBuilder $builder, $type = 'repeater', $config = [])
+    public function __construct($name, $type = 'repeater', $config = [], FieldsBuilder $builder = null)
     {
-        parent::__construct($name, $builder, $type, $config);
+        parent::__construct($name, $type, $config, $builder);
 
         if (!array_key_exists('button_label', $config)) {
             $this->setConfig('button_label', $this->getDefaultButtonLabel());

--- a/src/RepeaterBuilder.php
+++ b/src/RepeaterBuilder.php
@@ -21,9 +21,9 @@ class RepeaterBuilder extends GroupBuilder
      * @param string $type Field name
      * @param array $config Field configuration
      */
-    public function __construct($name, $type = 'repeater', $config = [])
+    public function __construct($name, FieldsBuilder $builder, $type = 'repeater', $config = [])
     {
-        parent::__construct($name, $type, $config);
+        parent::__construct($name, $builder, $type, $config);
 
         if (!array_key_exists('button_label', $config)) {
             $this->setConfig('button_label', $this->getDefaultButtonLabel());

--- a/tests/GroupBuilderTest.php
+++ b/tests/GroupBuilderTest.php
@@ -63,4 +63,11 @@ class GroupBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArraySubset($expectedConfig, $builder->build());
     }
+
+    public function testGroupBuilderWithInjectedFieldsBuilder()
+    {
+        $fieldsBuilder = new FieldsBuilder('fields_builder');
+        $builder = new GroupBuilder('group', 'group', [], $fieldsBuilder);
+        $this->assertSame($fieldsBuilder->getParentContext(), $builder);
+    }
 }

--- a/tests/GroupBuilderTest.php
+++ b/tests/GroupBuilderTest.php
@@ -9,7 +9,7 @@ class GroupBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testGroupBuilderCanAddFields()
     {
-        $builder = new GroupBuilder('background');
+        $builder = new GroupBuilder('background', new FieldsBuilder('background'));
 
         $builder->addColorPicker('color');
 
@@ -35,7 +35,7 @@ class GroupBuilderTest extends \PHPUnit_Framework_TestCase
             ->addNumber('width')
             ->addNumber('height');
 
-        $builder = new GroupBuilder('background');
+        $builder = new GroupBuilder('background', new FieldsBuilder('background'));
 
         $builder
             ->addColorPicker('color')

--- a/tests/GroupBuilderTest.php
+++ b/tests/GroupBuilderTest.php
@@ -9,7 +9,7 @@ class GroupBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testGroupBuilderCanAddFields()
     {
-        $builder = new GroupBuilder('background', new FieldsBuilder('background'));
+        $builder = new GroupBuilder('background');
 
         $builder->addColorPicker('color');
 
@@ -35,7 +35,7 @@ class GroupBuilderTest extends \PHPUnit_Framework_TestCase
             ->addNumber('width')
             ->addNumber('height');
 
-        $builder = new GroupBuilder('background', new FieldsBuilder('background'));
+        $builder = new GroupBuilder('background');
 
         $builder
             ->addColorPicker('color')

--- a/tests/RepeaterBuilderTest.php
+++ b/tests/RepeaterBuilderTest.php
@@ -9,7 +9,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuildRepeater()
     {
-        $builder = new RepeaterBuilder('slides');
+        $builder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
         $builder->addText('title')
                 ->addWysiwyg('content');
 
@@ -36,7 +36,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
                               ->setConstructorArgs(['parent'])
                               ->getMock();
 
-        $repeaterBuilder = new RepeaterBuilder('slides');
+        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
         $repeaterBuilder->setParentContext($fieldsBuilder);
 
         $fieldsBuilder->expects($this->once())->method('addText');
@@ -53,7 +53,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
                               ->setConstructorArgs(['parent'])
                               ->getMock();
 
-        $repeaterBuilder = new RepeaterBuilder('slides');
+        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
         $repeaterBuilder->setParentContext($fieldsBuilder);
 
         $fieldsBuilder->expects($this->once())->method('setLocation');
@@ -70,7 +70,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
             ->addText('title')
             ->addWysiwyg('content');
 
-        $repeaterBuilder = new RepeaterBuilder('slides');
+        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
         $repeaterBuilder
             ->addFields($banner)
             ->addImage('thumbnail');
@@ -92,7 +92,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $this->assertArraySubset($expectedConfig, $repeaterBuilder->build());
 
-        $repeaterBuilder = new RepeaterBuilder('slides');
+        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
         $repeaterBuilder
             ->addFields([
                 $banner->getField('title'),
@@ -104,7 +104,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testOverrideButton()
     {
-        $builder = new RepeaterBuilder('slides', 'repeater', ['button_label' => 'Add New Slide']);
+        $builder = new RepeaterBuilder('slides', new FieldsBuilder('slides'), 'repeater', ['button_label' => 'Add New Slide']);
         $builder->addText('title')
                 ->addWysiwyg('content');
 
@@ -128,7 +128,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCollapseSetting()
     {
-        $builder = new RepeaterBuilder('slides', 'repeater', ['collapsed' => 'title']);
+        $builder = new RepeaterBuilder('slides', new FieldsBuilder('slides'), 'repeater', ['collapsed' => 'title']);
         $builder->addText('title')
             ->addWysiwyg('content');
 

--- a/tests/RepeaterBuilderTest.php
+++ b/tests/RepeaterBuilderTest.php
@@ -9,7 +9,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuildRepeater()
     {
-        $builder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
+        $builder = new RepeaterBuilder('slides');
         $builder->addText('title')
                 ->addWysiwyg('content');
 
@@ -36,7 +36,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
                               ->setConstructorArgs(['parent'])
                               ->getMock();
 
-        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
+        $repeaterBuilder = new RepeaterBuilder('slides');
         $repeaterBuilder->setParentContext($fieldsBuilder);
 
         $fieldsBuilder->expects($this->once())->method('addText');
@@ -53,7 +53,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
                               ->setConstructorArgs(['parent'])
                               ->getMock();
 
-        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
+        $repeaterBuilder = new RepeaterBuilder('slides');
         $repeaterBuilder->setParentContext($fieldsBuilder);
 
         $fieldsBuilder->expects($this->once())->method('setLocation');
@@ -70,7 +70,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
             ->addText('title')
             ->addWysiwyg('content');
 
-        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
+        $repeaterBuilder = new RepeaterBuilder('slides');
         $repeaterBuilder
             ->addFields($banner)
             ->addImage('thumbnail');
@@ -92,7 +92,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $this->assertArraySubset($expectedConfig, $repeaterBuilder->build());
 
-        $repeaterBuilder = new RepeaterBuilder('slides', new FieldsBuilder('slides'));
+        $repeaterBuilder = new RepeaterBuilder('slides');
         $repeaterBuilder
             ->addFields([
                 $banner->getField('title'),
@@ -104,7 +104,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testOverrideButton()
     {
-        $builder = new RepeaterBuilder('slides', new FieldsBuilder('slides'), 'repeater', ['button_label' => 'Add New Slide']);
+        $builder = new RepeaterBuilder('slides', 'repeater', ['button_label' => 'Add New Slide']);
         $builder->addText('title')
                 ->addWysiwyg('content');
 
@@ -128,7 +128,7 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCollapseSetting()
     {
-        $builder = new RepeaterBuilder('slides', new FieldsBuilder('slides'), 'repeater', ['collapsed' => 'title']);
+        $builder = new RepeaterBuilder('slides', 'repeater', ['collapsed' => 'title']);
         $builder->addText('title')
             ->addWysiwyg('content');
 

--- a/tests/RepeaterBuilderTest.php
+++ b/tests/RepeaterBuilderTest.php
@@ -149,4 +149,11 @@ class RepeaterBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArraySubset($expectedConfig, $builder->build());
     }
+
+    public function testRepeaterBuilderWithInjectedFieldsBuilder()
+    {
+        $fieldsBuilder = new FieldsBuilder('fields_builder');
+        $builder = new RepeaterBuilder('repeater', 'repeater', [], $fieldsBuilder);
+        $this->assertSame($fieldsBuilder->getParentContext(), $builder);
+    }
 }


### PR DESCRIPTION
This update addresses https://github.com/StoutLogic/acf-builder/issues/96.

Suggestions for a different implementation are welcome.