### PR TITLE
Add choices tests with numeric values as keys

### DIFF
--- a/tests/ChoiceFieldBuilderTest.php
+++ b/tests/ChoiceFieldBuilderTest.php
@@ -94,4 +94,25 @@ class ChoiceFieldBuilderTest extends \PHPUnit_Framework_TestCase
             ]
         ], $config);
     }
+
+    public function testConfigInChoicesWithNumericKeys()
+    {
+        $subject = new ChoiceFieldBuilder('choice', 'radio', [
+            'label' => 'Are you finished?',
+            'allow_null' => true,
+            'required' => true,
+            'choices' => [
+                '1' => 'Yes',
+                '2' => 'No',
+            ]
+        ]);
+
+        $config = $subject->build();
+        $this->assertArraySubset([
+            'choices' => [
+                '1' => 'Yes',
+                '2' => 'No',
+            ]
+        ], $config);
+    }
 }


### PR DESCRIPTION
Hi @stevep 

I stumbled upon an issue with choices. Basically, I have a list a where the value is an ID (as string) and the label is string. 

```php
$choices = [
    '1' => 'Label 1',
    '8' => 'Label 8',
];
```

When adding those choices, I ended up with labels as values.

```html
<option value="Label 1">Label 1</option>
```

After digging a bit, I discovered that PHP casts keys when looping over an array. More on this: 
https://stackoverflow.com/questions/4100488/a-numeric-string-as-array-key-in-php

That's why Symfony changed the way they handle choices and use keys as labels (something I didn't understand until now): 
https://github.com/symfony/symfony/issues/19953

I didn't find a way to fix this without introducing a breaking change (choices formatted like Symfony does). That's why this PR only contains the test for this case.

The only workaround I found is to prevent the use of `choices` or `addChoices` with `addChoice`:

```php
foreach ($choices as $id => $label) {
    $builder->getField('select_field')->addChoice($id, $label);
}
```

Let me know what you think. 
