### PR TITLE
Fix clone FieldsBuilder from php

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -727,4 +727,9 @@ class FieldsBuilder extends ParentDelegationBuilder implements NamedBuilder
         return strtolower(str_replace(' ', '_', $name));
     }
 
+    public function __clone()
+    {
+        $this->fieldManager = clone $this->fieldManager;
+    }
+
 }


### PR DESCRIPTION
Have to clone fieldManager object when cloning FieldsBuilder object

```
Sample case:

$block = new FieldsBuilder('block');
$block->add....;

$block2 = clone $block;
$block2->modifyField(....);

$container = new FieldsBuilder('container');
$container->addGroup('group1')->addFields($block)->addGroup('group2')->addFields($block2);
```