### PR TITLE
feat: Add support for condition single operator (no value)

### DIFF
--- a/src/ConditionalBuilder.php
+++ b/src/ConditionalBuilder.php
@@ -18,9 +18,9 @@ class ConditionalBuilder extends ParentDelegationBuilder
      * Creates the first rule. Additional rules can be chained use `or` and `and`
      * @param string $name
      * @param string $operator
-     * @param string $value
+     * @param string|null $value
      */
-    public function __construct($name, $operator, $value)
+    public function __construct($name, $operator, $value = null)
     {
         $this->and($name, $operator, $value);
     }
@@ -38,10 +38,10 @@ class ConditionalBuilder extends ParentDelegationBuilder
      * Creates an AND condition
      * @param  string $name
      * @param  string $operator
-     * @param  string $value
+     * @param  string|null $value
      * @return $this
      */
-    public function andCondition($name, $operator, $value)
+    public function andCondition($name, $operator, $value = null)
     {
         $orCondition = $this->popOrCondition();
         $orCondition[] = $this->createCondition($name, $operator, $value);
@@ -54,10 +54,10 @@ class ConditionalBuilder extends ParentDelegationBuilder
      * Creates an OR condition
      * @param  string $name
      * @param  string $operator
-     * @param  string $value
+     * @param  string|null $value
      * @return $this
      */
-    public function orCondition($name, $operator, $value)
+    public function orCondition($name, $operator, $value = null)
     {
         $condition = $this->createCondition($name, $operator, $value);
         $this->pushOrCondition([$condition]);
@@ -69,16 +69,16 @@ class ConditionalBuilder extends ParentDelegationBuilder
      * Creates a condition
      * @param  string $name
      * @param  string $operator
-     * @param  string $value
+     * @param  string|null $value
      * @return array
      */
-    protected function createCondition($name, $operator, $value)
+    protected function createCondition($name, $operator, $value = null)
     {
-        return [
+        return array_filter([
             'field' => $name,
             'operator' => $operator,
             'value' => $value,
-        ];
+        ], fn($value) => $value !== null);
     }
 
     /**

--- a/src/LocationBuilder.php
+++ b/src/LocationBuilder.php
@@ -14,8 +14,12 @@ class LocationBuilder extends ConditionalBuilder
      * @param  string $value
      * @return array
      */
-    protected function createCondition($name, $operator, $value)
+    protected function createCondition($name, $operator, $value = '')
     {
+        if ($value === '') {
+            throw new \InvalidArgumentException('Value is required for location conditions');
+        }
+
         return [
             'param' => $name,
             'operator' => $operator,

--- a/tests/ConditionalBuilderTest.php
+++ b/tests/ConditionalBuilderTest.php
@@ -9,7 +9,7 @@ use StoutLogic\AcfBuilder\ConditionalBuilder;
 class ConditionalBuilderTest extends TestCase
 {
     use ArraySubsetAsserts;
-    
+
     public function testContionalLogic()
     {
         $builder = new ConditionalBuilder('color', '==', 'other');
@@ -25,6 +25,22 @@ class ConditionalBuilderTest extends TestCase
         ];
 
         $this->assertArraySubset($expectedConfig, $builder->build());
+    }
+
+    public function testContionalLogicOperatorOnly()
+    {
+        $builder = new ConditionalBuilder('color', '!=empty');
+
+        $expectedConfig = [
+            [
+                [
+                    'field' => 'color',
+                    'operator'  =>  '!=empty',
+                ],
+            ]
+        ];
+
+        $this->assertSame($expectedConfig, $builder->build());
     }
 
     public function testAnd()


### PR DESCRIPTION
Hey @stevep, 

ACF is now providing some single operator (e.g. no mandatory value):

```php
'conditional_logic' => array(
    array(
        array(
            'field' => 'field_66db320aef59b',
            'operator' => '==empty',
        ),
    ),
),
```

This PR adds support for them.

Since the `LocationBuilder` is extending the `Conditionalbuilder`, I had to make the `LocationBuilder::createCondition` compatible, hence the exception throw.

Let me know if this needs any changes.