### PR TITLE
feat: Enhance ChoiceFieldBuilder to support numeric choice keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 vendor
 node_modules
 .idea
+.vscode
 .stignore
 .stversions
 .stfolder
 .phpunit.result.cache
+

--- a/src/ChoiceFieldBuilder.php
+++ b/src/ChoiceFieldBuilder.php
@@ -51,21 +51,40 @@ class ChoiceFieldBuilder extends FieldBuilder
             $choices = func_get_args();
         }
 
+        $isIndexedArray = array_keys($choices) === range(0, count($choices) - 1);
+
         foreach ($choices as $key => $value) {
-            $label = $choice = $value;
-
-            if (is_array($choice)) {
-                $label = array_values($choice)[0];
-                $choice = array_keys($choice)[0];
-            } else if (is_string($key)) {
-                $choice = $key;
-                $label = $value;
-            }
-
-            $this->addChoice($choice, $label);
+            $parsed = $this->parseChoiceItem($key, $value, $isIndexedArray);
+            $this->addChoice($parsed[0], $parsed[1]);
         }
 
         return $this;
+    }
+
+    /**
+     * Parse a choice item to extract the choice value and label.
+     * 
+     * @param mixed $key The array key
+     * @param mixed $value The array value
+     * @param bool $isIndexedArray Whether the parent array is indexed (0, 1, 2...)
+     * @return array [$choice, $label]
+     */
+    private function parseChoiceItem($key, $value, $isIndexedArray)
+    {
+        // Handle associative array choice: ['choice' => 'label']
+        if (is_array($value)) {
+            $choice = array_keys($value)[0];
+            $label = array_values($value)[0];
+            return [$choice, $label];
+        }
+
+        // Handle a choice without a label, use the value as both choice and label
+        if ($isIndexedArray) {
+            return [$value, $value];
+        }
+
+        // Handle choice array format where the key is explicitly defined
+        return [$key, $value];
     }
 
     /**

--- a/tests/ChoiceFieldBuilderTest.php
+++ b/tests/ChoiceFieldBuilderTest.php
@@ -9,7 +9,8 @@ use StoutLogic\AcfBuilder\ChoiceFieldBuilder;
 class ChoiceFieldBuilderTest extends TestCase
 {
     use ArraySubsetAsserts;
-    
+
+
     public function testClassExists()
     {
         $this->assertTrue(class_exists('StoutLogic\AcfBuilder\ChoiceFieldBuilder'));
@@ -94,6 +95,28 @@ class ChoiceFieldBuilderTest extends TestCase
             'choices' => [
                 'yes' => 'Yes, please send my report for review!',
                 'no' => 'No, save my report for later completion.',
+            ]
+        ], $config);
+    }
+
+    public function testNumericChoiceKeysWithLabels()
+    {
+        $subject = new ChoiceFieldBuilder('test_with_keys', 'radio', [
+            'choices' => [
+                1 => 'one',
+                2 => 'two',
+                5 => 'five',
+                '2.5' => '2 and a half',
+            ]
+        ]);
+
+        $config = $subject->build();
+        $this->assertArraySubset([
+            'choices' => [
+                1 => 'one',
+                2 => 'two',
+                5 => 'five',
+                '2.5' => '2 and a half',
             ]
         ], $config);
     }


### PR DESCRIPTION
This PR fixes a bug in the ChoiceFieldBuilder::addChoices() method that prevented us from setting explicit numeric keys without resulting to passing a choice as a Associative array.

The refactored code correctly handles all choice formats:

- Indexed arrays: ['red', 'blue'] → 'red' => 'red', 'blue' => 'blue'
- Associative arrays: ['yes' => 'Yes, please...'] → 'yes' => 'Yes, please...'
- Nested arrays: [['blue' => 'Blue']] → 'blue' => 'Blue'
- Numeric keys: [1 => 'one', 100 => 'one hundred'] → preserved as-is

Added an additional test to test the new supported format as well.

Fixes #125 at least with the numeric keys.